### PR TITLE
S3 AuthenticatedUsers Permission Alert

### DIFF
--- a/s3_bucket_authenticatedusers.rb
+++ b/s3_bucket_authenticatedusers.rb
@@ -1,6 +1,5 @@
 configure do |c|
     c.deep_inspection = [:bucket_name, :acl]
-    c.valid_regions = [:us_east_1]
     c.unique_identifier = [:bucket_name]
 end
 

--- a/s3_bucket_authenticatedusers.rb
+++ b/s3_bucket_authenticatedusers.rb
@@ -1,0 +1,34 @@
+configure do |c|
+    c.deep_inspection = [:bucket_name, :acl]
+    c.valid_regions = [:us_east_1]
+    c.unique_identifier = [:bucket_name]
+end
+
+def perform(aws)
+    
+    aws.s3.list_buckets[:buckets].each do |bucket|
+        acl = nil
+        name = bucket[:name]
+        
+        acl = aws.s3.get_bucket_acl(bucket: name)
+        acl.grants.each do |grant|
+            permission = grant.permission
+            grantee = grant.grantee
+            set_data(bucket_name: name, acl: acl, bucket: bucket)
+
+
+            if grantee.uri != nil
+                if grantee.uri =~ /AuthenticatedUsers$/
+                  fail(message: "Bucket uses AuthenticatedUsers permission #{name}", resource_id: name)
+                end
+
+            end
+       
+        end
+
+
+    end
+
+end
+
+


### PR DESCRIPTION
Add rule that will alert if any S3 buckets are configured with the AuthenticatedUsers S3 bucket permission which would make the bucket world readable or writable to anyone with an AWS account as long as the user had authenticated to AWS prior